### PR TITLE
Introduce make:action command to generate action classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This package provides Laravel Eloquent support, traits, and additional classes.
     - [HasUuid Trait](#hasuuid-trait)
     - [HasRouteBinding](#HasRouteBinding)
     - [HasStaticAccess](#hasstaticaccess)
+- [Commands](#commands)
 - [Support](#support)
     - [Traits](#support-traits)
     - [Path](#support-path)
@@ -317,6 +318,17 @@ User::findByRouteKey($key); // Alias of findByKey
 - Static access without instantiate.
 - Improved readability – Clear intent in routing, and helpers.
 - Zero side effects – Uses fresh model instances internally.
+
+## Commands
+
+The package provides few commands that are frequntly used for every project
+
+### Make action class
+
+```bash
+php artisan make:action CreateExampleAction
+php artisan make:action CreateExampleAction -i # invokable
+```
 
 ## Support
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,9 @@
     },
     "extra": {
         "laravel": {
-            "providers": []
+            "providers": [
+                "SaeedHosan\\Useful\\UsefulServiceProvider"
+            ]
         }
     },
     "scripts": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,5 @@ parameters:
 
     ignoreErrors:
         - identifier: trait.unused
-        - '#PHPDoc tag @var#'
+        - "#PHPDoc tag @var#"
+        - "#Cannot cast mixed#"

--- a/src/Console/Commands/ActionMakeCommand.php
+++ b/src/Console/Commands/ActionMakeCommand.php
@@ -38,7 +38,7 @@ class ActionMakeCommand extends GeneratorCommand
      */
     protected function resolveStubPath(string $stub)
     {
-        return file_exists($customPath = $this->laravel->basePath(mb_trim($stub, '/')))
+        return file_exists($customPath = $this->laravel->basePath((string) mb_trim($stub, '/')))
             ? $customPath
             : __DIR__.$stub;
     }

--- a/src/Console/Commands/ActionMakeCommand.php
+++ b/src/Console/Commands/ActionMakeCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SaeedHosan\Useful\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Override;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:action', description: 'Create a new action class')]
+class ActionMakeCommand extends GeneratorCommand
+{
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Class';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->option('invokable')
+            ? $this->resolveStubPath('/stubs/action.invokable.stub')
+            : $this->resolveStubPath('/stubs/action.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @return string
+     */
+    protected function resolveStubPath(string $stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(mb_trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    #[Override]
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Actions';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array<int, array<int, mixed>>
+     */
+    #[Override]
+    protected function getOptions()
+    {
+        return [
+            ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable action'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the action even if the class already exists'],
+        ];
+    }
+}

--- a/src/Console/Commands/stubs/action.invokable.stub
+++ b/src/Console/Commands/stubs/action.invokable.stub
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use Illuminate\Support\Facades\DB;
+
+final readonly class {{ class }}
+{
+    /**
+     * Execute the action.
+     */
+    public function __invoke(): void
+    {
+        DB::transaction(function (): void {
+            //
+        });
+    }
+}

--- a/src/Console/Commands/stubs/action.stub
+++ b/src/Console/Commands/stubs/action.stub
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use Illuminate\Support\Facades\DB;
+
+final readonly class {{ class }}
+{
+    /**
+     * Execute the action.
+     */
+    public function handle(): void
+    {
+        DB::transaction(function (): void {
+            //
+        });
+    }
+}

--- a/src/Console/Commands/stubs/response.invokable.stub
+++ b/src/Console/Commands/stubs/response.invokable.stub
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Support\Responsable;
+
+class {{ class }} implements Responsable
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function __invoke($request)
+    {
+        return $this->toResponse($request);
+    }
+
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return response();
+    }
+}

--- a/src/Console/Commands/stubs/response.stub
+++ b/src/Console/Commands/stubs/response.stub
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Support\Responsable;
+
+class {{ class }} implements Responsable
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return response('The response content');
+    }
+}

--- a/src/UsefulServiceProvider.php
+++ b/src/UsefulServiceProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SaeedHosan\Useful;
+
+use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+
+class UsefulServiceProvider extends BaseServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        $this->publishStubs();
+        $this->registerCommands();
+    }
+
+    private function publishStubs(): void
+    {
+        if (! $this->app->runningInConsole()) {
+            return;
+        }
+
+        $this->publishes([
+            __DIR__.'/Console/Commands/stubs' => base_path('stubs'),
+        ], 'useful-stubs');
+    }
+
+    private function registerCommands(): void
+    {
+        if (! $this->app->runningInConsole()) {
+            return;
+        }
+
+        $this->commands([
+            Console\Commands\ActionMakeCommand::class,
+        ]);
+    }
+}

--- a/tests/Commands/ActionMakeCommandTest.php
+++ b/tests/Commands/ActionMakeCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+test('action make command creates a basic action class', function () {
+
+    /** @var TestCase $this */
+    $this->artisan('make:action', ['name' => 'TestAction'])->assertExitCode(0);
+
+    expect(File::exists(app_path('Actions/TestAction.php')))->toBeTrue();
+
+    $content = File::get(app_path('Actions/TestAction.php'));
+    expect($content)->toContain('final readonly class TestAction');
+    expect($content)->toContain('public function handle(): void');
+    expect($content)->toContain('DB::transaction');
+
+    File::deleteDirectory(app_path('Actions'));
+});
+
+test('action make command creates an invokable action', function () {
+
+    /** @var TestCase $this */
+    $this->artisan('make:action', [
+        'name' => 'InvokableAction',
+        '--invokable' => true,
+    ])->assertExitCode(0);
+
+    expect(File::exists(app_path('Actions/InvokableAction.php')))->toBeTrue();
+
+    $content = File::get(app_path('Actions/InvokableAction.php'));
+    expect($content)->toContain('final readonly class InvokableAction');
+    expect($content)->toContain('public function __invoke(): void');
+    expect($content)->toContain('DB::transaction');
+
+    File::deleteDirectory(app_path('Actions'));
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Tests;
 
 use Orchestra\Testbench\TestCase as Orchestra;
+use SaeedHosan\Useful\UsefulServiceProvider;
 
 abstract class TestCase extends Orchestra
 {
     protected function getPackageProviders($app): array
     {
         return [
-            // ServiceProvider::class
+            UsefulServiceProvider::class,
         ];
     }
 

--- a/tests/UsefulServiceProviderTest.php
+++ b/tests/UsefulServiceProviderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use SaeedHosan\Useful\UsefulServiceProvider;
+use Tests\TestCase;
+
+test('service provider has register and boot methods', function () {
+    /** @var TestCase $this */
+    $provider = new UsefulServiceProvider($this->app);
+
+    expect(method_exists($provider, 'register'))->toBeTrue();
+    expect(method_exists($provider, 'boot'))->toBeTrue();
+});
+
+test('service provider registers action make command', function () {
+    /** @var TestCase $this */
+    $provider = new UsefulServiceProvider($this->app);
+    $provider->boot();
+
+    $commands = Artisan::all();
+    expect(isset($commands['make:action']))->toBeTrue();
+});
+
+test('service provider publishes stubs', function () {
+    /** @var TestCase $this */
+    new UsefulServiceProvider($this->app);
+
+    $this->artisan('vendor:publish', ['--tag' => 'useful-stubs'])->assertExitCode(0);
+
+    expect(File::exists(base_path('stubs/action.stub')))->toBeTrue();
+    expect(File::exists(base_path('stubs/action.invokable.stub')))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Adds `make:action` Artisan command to generate action classes
- Supports basic actions with `handle()` method and invokable actions with `__invoke()` method
- Includes full test coverage for the command and service provider
- Actions are generated in `App\Actions` namespace by default