### PR TITLE
Introduce make:response command to generate response classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,13 @@ php artisan make:action CreateExampleAction
 php artisan make:action CreateExampleAction -i # invokable
 ```
 
+### Make response class
+
+```bash
+php artisan make:response CreateExampleResponse
+php artisan make:response CreateExampleResponse -i # invokable
+```
+
 ### EnvEditor
 
 The `EnvEditor` support class provides a simple, safe way to read and modify Laravel `.env` environment variables.

--- a/src/Console/Commands/ResponseMakeClass.php
+++ b/src/Console/Commands/ResponseMakeClass.php
@@ -38,7 +38,7 @@ class ResponseMakeClass extends GeneratorCommand
      */
     protected function resolveStubPath(string $stub)
     {
-        return file_exists($customPath = $this->laravel->basePath(mb_trim($stub, '/')))
+        return file_exists($customPath = $this->laravel->basePath((string) mb_trim($stub, '/')))
             ? $customPath
             : __DIR__.$stub;
     }

--- a/src/Console/Commands/ResponseMakeClass.php
+++ b/src/Console/Commands/ResponseMakeClass.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SaeedHosan\Useful\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Override;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:response', description: 'Create a new http response class')]
+class ResponseMakeClass extends GeneratorCommand
+{
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Class';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->option('invokable')
+            ? $this->resolveStubPath('/stubs/response.invokable.stub')
+            : $this->resolveStubPath('/stubs/response.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @return string
+     */
+    protected function resolveStubPath(string $stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(mb_trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    #[Override]
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Http\Responses';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array<int, array<int, mixed>>
+     */
+    #[Override]
+    protected function getOptions()
+    {
+        return [
+            ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable action'],
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the action even if the class already exists'],
+        ];
+    }
+}

--- a/src/Console/Commands/stubs/response.stub
+++ b/src/Console/Commands/stubs/response.stub
@@ -16,6 +16,6 @@ class {{ class }} implements Responsable
      */
     public function toResponse($request)
     {
-        return response('The response content');
+        return response('The response content is empty');
     }
 }

--- a/src/UsefulServiceProvider.php
+++ b/src/UsefulServiceProvider.php
@@ -44,6 +44,7 @@ class UsefulServiceProvider extends BaseServiceProvider
 
         $this->commands([
             Console\Commands\ActionMakeCommand::class,
+            Console\Commands\ResponseMakeClass::class,
         ]);
     }
 }

--- a/tests/Commands/ResponseMakeClassTest.php
+++ b/tests/Commands/ResponseMakeClassTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+test('response make command creates a basic response class', function () {
+
+    /** @var TestCase $this */
+    $this->artisan('make:response', ['name' => 'TestResponse'])->assertExitCode(0);
+
+    expect(File::exists(app_path('Http/Responses/TestResponse.php')))->toBeTrue();
+
+    $content = File::get(app_path('Http/Responses/TestResponse.php'));
+    expect($content)->toContain('class TestResponse implements Responsable');
+    expect($content)->toContain('public function toResponse($request)');
+
+    File::deleteDirectory(app_path('Http/Responses'));
+});
+
+test('response make command creates an invokable response', function () {
+
+    /** @var TestCase $this */
+    $this->artisan('make:response', [
+        'name' => 'InvokableResponse',
+        '--invokable' => true,
+    ])->assertExitCode(0);
+
+    expect(File::exists(app_path('Http/Responses/InvokableResponse.php')))->toBeTrue();
+
+    $content = File::get(app_path('Http/Responses/InvokableResponse.php'));
+    expect($content)->toContain('class InvokableResponse implements Responsable');
+    expect($content)->toContain('public function __invoke($request)');
+    expect($content)->toContain('public function toResponse($request)');
+
+    File::deleteDirectory(app_path('Http/Responses'));
+});


### PR DESCRIPTION
## Summary
- Add `make:response` Artisan command to generate HTTP response classes
- Support both basic and invokable response class generation
- Add test suite for the new command

## Changes
- New `ResponseMakeClass` command in `src/Console/Commands/`
- Response stubs for basic and invokable classes
- Test file `tests/Commands/ResponseMakeClassTest.php`
- Register command in `UsefulServiceProvider`

## Usage
```bash
php artisan make:response TestResponse
php artisan make:response InvokableResponse --invokable
```